### PR TITLE
Select folder path in MacOS and change path

### DIFF
--- a/lib/data/lcu/lcu.dart
+++ b/lib/data/lcu/lcu.dart
@@ -217,4 +217,8 @@ class LCU {
     _websocket.close();
     _restClient.close();
   }
+
+  void resetPath() {
+    _lcuStore.clear();
+  }
 }

--- a/lib/data/lcu/lcu_path_storage.dart
+++ b/lib/data/lcu/lcu_path_storage.dart
@@ -19,6 +19,10 @@ class LcuPathStorage {
     return File(path);
   }
 
+  void clearLockfile() {
+    _sharedPreferences.remove(_spLockfilePathKey);
+  }
+
   Future<void> putLcuLockfilePath(String lockfilePath) async {
     await _sharedPreferences.setString(_spLockfilePathKey, lockfilePath);
   }

--- a/lib/data/lcu/lcu_path_storage.dart
+++ b/lib/data/lcu/lcu_path_storage.dart
@@ -19,7 +19,7 @@ class LcuPathStorage {
     return File(path);
   }
 
-  void clearLockfile() {
+  void clear() {
     _sharedPreferences.remove(_spLockfilePathKey);
   }
 

--- a/lib/presentation/core/l10n/app_en.arb
+++ b/lib/presentation/core/l10n/app_en.arb
@@ -81,7 +81,7 @@
   "itemBuildSituationalBlock": "[Sebby] Situational items",
   "itemBuildStartingBlock": "[Sebby] Starting items",
   "lolPathPickerDialogTitle": "Pick «League of Legends» folder",
-  "lolPathPickerMessageInitial": "Hello, i'm Sebastian\n\\nI could not find where you find the league of legends client…\\n\\nIf it is not running then run it and retry.\\nIf it still doesn't work, then show me the path to the folder with the file \"LeagueClient.exe\"",
+  "lolPathPickerMessageInitial": "Hello, i'm Sebastian\n\nI could not find where you find the league of legends client…\n\nIf it is not running then run it and retry.\nIf it still doesn't work, then show me the path to the folder with the file \"LeagueClient.exe\"",
   "lolPathPickerMessageWrongPath": "I can't find the league of legends files in the selected folder",
   "lolPathPickerPickPathButton": "PICK PATH",
   "masteryTableColumnChampion": "Champion",

--- a/lib/presentation/core/l10n/app_en.arb
+++ b/lib/presentation/core/l10n/app_en.arb
@@ -17,6 +17,7 @@
   "buildDetailsSkills": "Skills",
   "buildDetailsSummonerSpells": "Summoner spells",
   "buttonRetry": "RETRY",
+  "buttonChangePath": "Change path",
   "championPickImportButton": "IMPORT",
   "championPickNoBuildsMessage": "There are no builds for the selected role 🥲",
   "championPickNoPickedChampionMessage": "Pick champion 🙃",

--- a/lib/presentation/core/l10n/app_ru.arb
+++ b/lib/presentation/core/l10n/app_ru.arb
@@ -17,6 +17,7 @@
   "buildDetailsSkills": "Заклинания",
   "buildDetailsSummonerSpells": "Самонерки",
   "buttonRetry": "ПОВТОРИТЬ",
+  "buttonChangePath": "Измените путь",
   "championPickImportButton": "ИМПОРТИРОВАТЬ",
   "championPickNoBuildsMessage": "Для выбранной роли нет сборок 🥲",
   "championPickNoPickedChampionMessage": "Давай выбирай, ну... 🙃",

--- a/lib/presentation/home/bloc/home_bloc.dart
+++ b/lib/presentation/home/bloc/home_bloc.dart
@@ -5,7 +5,6 @@ import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 
 import 'package:sebastian/data/lcu/lcu.dart';
-import 'package:sebastian/data/lcu/lcu_path_storage.dart';
 import 'package:sebastian/data/lcu/models/ready_check_event.dart';
 import 'package:sebastian/data/repositories/champion_repository.dart';
 import 'package:sebastian/data/repositories/items_repository.dart';
@@ -21,7 +20,6 @@ part 'home_state.dart';
 
 class HomeBloc extends Bloc<HomeEvent, HomeState> with StreamSubscriptions {
   final LCU _lcu;
-  final LcuPathStorage _lcuStore;
   final SummonerRepository _summonerRepository;
   final ChampionRepository _championRepository;
   final PerksRepository _perksRepository;
@@ -31,7 +29,6 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> with StreamSubscriptions {
 
   HomeBloc(
     this._lcu,
-    this._lcuStore,
     this._summonerRepository,
     this._championRepository,
     this._perksRepository,
@@ -82,8 +79,8 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> with StreamSubscriptions {
   }
 
   Future<void> _onTapClearLolPathHomeEvent(TapClearLolPathHomeEvent event, Emitter<HomeState> emit) async {
-    _lcuStore.clear();
-    add(StartHomeEvent());
+    _lcu.resetPath();
+    emit(LolPathUnspecifiedHomeState());
   }
 
   Future<void> _onLoadCurrentSummonerInfoHomeEvent(

--- a/lib/presentation/home/bloc/home_event.dart
+++ b/lib/presentation/home/bloc/home_event.dart
@@ -20,6 +20,8 @@ class TapDestinationHomeEvent extends HomeEvent {
   TapDestinationHomeEvent(this.destination);
 }
 
+class TapClearLolPathHomeEvent extends HomeEvent {}
+
 class ToggleAutoAcceptHomeEvent extends HomeEvent {}
 
 class LcuDisconnectedHomeEvent extends HomeEvent {}

--- a/lib/presentation/home/home_page.dart
+++ b/lib/presentation/home/home_page.dart
@@ -51,6 +51,9 @@ class HomePage extends StatelessWidget {
               LolNotLaunchedOrWrongPathProvidedHomeState _ => MessageWithRetryScreen(
                   message: appLocalizations.homeMessageLolOffline,
                   onTapRetry: () => context.read<HomeBloc>().add(StartHomeEvent()),
+                  onTapChangePath: () => context
+                      .read<HomeBloc>()
+                      .add(PickLolPathHomeEvent(pickedPath: '')),
                 ),
               ErrorHomeState _ => MessageWithRetryScreen(
                   message: state.message,

--- a/lib/presentation/home/home_page.dart
+++ b/lib/presentation/home/home_page.dart
@@ -10,6 +10,7 @@ import 'package:sebastian/presentation/champions_disenchanter/champions_disencha
 import 'package:sebastian/presentation/champions_table/champions_table_widget.dart';
 import 'package:sebastian/presentation/champions_tier_list/champions_tier_list_widget.dart';
 import 'package:sebastian/presentation/core/widgets/app_version.dart';
+import 'package:sebastian/presentation/home/screens/lol_not_launched_or_wrong_path.dart';
 import 'package:sebastian/presentation/summoner/summoner_widget.dart';
 
 import 'bloc/home_bloc.dart';
@@ -33,6 +34,7 @@ class HomePage extends StatelessWidget {
         getIt(),
         getIt(),
         getIt(),
+        getIt(),
       )..add(StartHomeEvent()),
       child: Scaffold(
         body: BlocBuilder<HomeBloc, HomeState>(
@@ -48,12 +50,10 @@ class HomePage extends StatelessWidget {
                   onRetryTap: () => context.read<HomeBloc>().add(StartHomeEvent()),
                   onPickedPath: (path) => context.read<HomeBloc>().add(PickLolPathHomeEvent(pickedPath: path)),
                 ),
-              LolNotLaunchedOrWrongPathProvidedHomeState _ => MessageWithRetryScreen(
+              LolNotLaunchedOrWrongPathProvidedHomeState _ => LolNotLaunchedOrWrongPathProvidedScreen(
                   message: appLocalizations.homeMessageLolOffline,
                   onTapRetry: () => context.read<HomeBloc>().add(StartHomeEvent()),
-                  onTapChangePath: () => context
-                      .read<HomeBloc>()
-                      .add(PickLolPathHomeEvent(pickedPath: '')),
+                  onTapChangePath: () => context.read<HomeBloc>().add(TapClearLolPathHomeEvent()),
                 ),
               ErrorHomeState _ => MessageWithRetryScreen(
                   message: state.message,

--- a/lib/presentation/home/home_page.dart
+++ b/lib/presentation/home/home_page.dart
@@ -34,7 +34,6 @@ class HomePage extends StatelessWidget {
         getIt(),
         getIt(),
         getIt(),
-        getIt(),
       )..add(StartHomeEvent()),
       child: Scaffold(
         body: BlocBuilder<HomeBloc, HomeState>(

--- a/lib/presentation/home/screens/lol_not_launched_or_wrong_path.dart
+++ b/lib/presentation/home/screens/lol_not_launched_or_wrong_path.dart
@@ -4,15 +4,17 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'package:sebastian/presentation/core/widgets/sebastian_message.dart';
 
-class MessageWithRetryScreen extends StatelessWidget {
-  const MessageWithRetryScreen({
+class LolNotLaunchedOrWrongPathProvidedScreen extends StatelessWidget {
+  const LolNotLaunchedOrWrongPathProvidedScreen({
     super.key,
     required this.message,
     required this.onTapRetry,
+    this.onTapChangePath,
   });
 
   final String message;
   final VoidCallback onTapRetry;
+  final VoidCallback? onTapChangePath;
 
   @override
   Widget build(BuildContext context) {
@@ -29,6 +31,11 @@ class MessageWithRetryScreen extends StatelessWidget {
             OutlinedButton(
               onPressed: onTapRetry,
               child: Text(appLocalizations.buttonRetry),
+            ),
+            const SizedBox(height: 12),
+            OutlinedButton(
+              onPressed: onTapChangePath,
+              child: Text(appLocalizations.buttonChangePath),
             ),
           ],
         ),

--- a/lib/presentation/home/screens/message_with_retry.dart
+++ b/lib/presentation/home/screens/message_with_retry.dart
@@ -9,10 +9,12 @@ class MessageWithRetryScreen extends StatelessWidget {
     super.key,
     required this.message,
     required this.onTapRetry,
+    this.onTapChangePath,
   });
 
   final String message;
   final VoidCallback onTapRetry;
+  final VoidCallback? onTapChangePath;
 
   @override
   Widget build(BuildContext context) {
@@ -29,6 +31,11 @@ class MessageWithRetryScreen extends StatelessWidget {
             OutlinedButton(
               onPressed: onTapRetry,
               child: Text(appLocalizations.buttonRetry),
+            ),
+            const SizedBox(height: 12),
+            OutlinedButton(
+              onPressed: onTapChangePath,
+              child: Text(appLocalizations.buttonChangePath),
             ),
           ],
         ),

--- a/lib/presentation/home/screens/pick_lol_path.dart
+++ b/lib/presentation/home/screens/pick_lol_path.dart
@@ -1,7 +1,10 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:sebastian/data/lcu/lcu.dart';
 
 import 'package:sebastian/presentation/core/widgets/sebastian_message.dart';
 
@@ -18,10 +21,19 @@ class PickLolPathScreen extends StatelessWidget {
   final void Function(String) onPickedPath;
 
   Future<void> _onPickPathTap(String dialogTitle) async {
-    final result = await FilePicker.platform.getDirectoryPath(
-      lockParentWindow: true,
-      dialogTitle: dialogTitle,
-    );
+    String? result;
+
+    if (!Platform.isMacOS) {
+      result = await FilePicker.platform.getDirectoryPath(
+        lockParentWindow: true,
+        dialogTitle: dialogTitle,
+      );
+    } else {
+      final files = await FilePicker.platform.pickFiles(type: FileType.custom, allowedExtensions: [LCU.macosFileType]);
+      if (files != null) {
+        result = files.files.single.path;
+      }
+    }
 
     if (result != null) {
       onPickedPath(result);

--- a/lib/presentation/home/screens/pick_lol_path.dart
+++ b/lib/presentation/home/screens/pick_lol_path.dart
@@ -23,16 +23,16 @@ class PickLolPathScreen extends StatelessWidget {
   Future<void> _onPickPathTap(String dialogTitle) async {
     String? result;
 
-    if (!Platform.isMacOS) {
+    if (Platform.isMacOS) {
+      final files = await FilePicker.platform.pickFiles(type: FileType.custom, allowedExtensions: [LCU.macosFileExtension]);
+      if (files != null) {
+        result = files.files.single.path;
+      }
+    } else {
       result = await FilePicker.platform.getDirectoryPath(
         lockParentWindow: true,
         dialogTitle: dialogTitle,
       );
-    } else {
-      final files = await FilePicker.platform.pickFiles(type: FileType.custom, allowedExtensions: [LCU.macosFileType]);
-      if (files != null) {
-        result = files.files.single.path;
-      }
     }
 
     if (result != null) {


### PR DESCRIPTION
Today I discovered that the lol client has local api's that provide live game information. While looking for more data to experiment (also with flutter) I found this repository, it's great but I found some problems on macOS. It wouldn't let me choose the .app file to read the lockfile and when I happened to select a non-League RiotClient folder it wouldn't let me change the path which made it unusable.

This PR fixes these problems (at least the ones that happened to me)

Translated with DeepL.com (free version) :p